### PR TITLE
BUG: ITKv5 uses threading callback signature changes per platform

### DIFF
--- a/TubeTKLib/Filtering/itktubeAnisotropicDiffusionTensorImageFilter.h
+++ b/TubeTKLib/Filtering/itktubeAnisotropicDiffusionTensorImageFilter.h
@@ -204,11 +204,11 @@ private:
 
   /** This callback method uses ImageSource::SplitRequestedRegion to acquire an
    * output region that it passes to ThreadedApplyUpdate for processing. */
-  static ITK_THREAD_RETURN_TYPE ApplyUpdateThreaderCallback( void *arg );
+  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION ApplyUpdateThreaderCallback( void *arg );
 
   /** This callback method uses SplitUpdateContainer to acquire a region
    * which it then passes to ThreadedCalculateChange for processing. */
-  static ITK_THREAD_RETURN_TYPE CalculateChangeThreaderCallback( void *arg );
+  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION CalculateChangeThreaderCallback( void *arg );
 
   typename DiffusionTensorImageType::Pointer            m_DiffusionTensorImage;
 

--- a/TubeTKLib/Filtering/itktubeAnisotropicDiffusionTensorImageFilter.hxx
+++ b/TubeTKLib/Filtering/itktubeAnisotropicDiffusionTensorImageFilter.hxx
@@ -216,7 +216,7 @@ AnisotropicDiffusionTensorImageFilter<TInputImage, TOutputImage>
 }
 
 template< class TInputImage, class TOutputImage >
-ITK_THREAD_RETURN_TYPE
+ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 AnisotropicDiffusionTensorImageFilter<TInputImage, TOutputImage>
 ::ApplyUpdateThreaderCallback( void * arg )
 {
@@ -288,7 +288,7 @@ AnisotropicDiffusionTensorImageFilter<TInputImage, TOutputImage>
 }
 
 template< class TInputImage, class TOutputImage >
-ITK_THREAD_RETURN_TYPE
+ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 AnisotropicDiffusionTensorImageFilter<TInputImage, TOutputImage>
 ::CalculateChangeThreaderCallback( void * arg )
 {

--- a/TubeTKLib/Registration/itktubeAnisotropicDiffusiveRegistrationFilter.h
+++ b/TubeTKLib/Registration/itktubeAnisotropicDiffusiveRegistrationFilter.h
@@ -338,7 +338,7 @@ private:
    * acquire an output region that it passes to
    * ThreadedGetNormalsAndDistancesFromClosestSurfacePoint for
    * processing. */
-  static ITK_THREAD_RETURN_TYPE
+  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
       GetNormalsAndDistancesFromClosestSurfacePointThreaderCallback(
           void * arg );
 

--- a/TubeTKLib/Registration/itktubeAnisotropicDiffusiveRegistrationFilter.hxx
+++ b/TubeTKLib/Registration/itktubeAnisotropicDiffusiveRegistrationFilter.hxx
@@ -358,7 +358,7 @@ AnisotropicDiffusiveRegistrationFilter
  * processing
  */
 template< class TFixedImage, class TMovingImage, class TDeformationField >
-ITK_THREAD_RETURN_TYPE
+ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 AnisotropicDiffusiveRegistrationFilter
   < TFixedImage, TMovingImage, TDeformationField >
 ::GetNormalsAndDistancesFromClosestSurfacePointThreaderCallback(

--- a/TubeTKLib/Registration/itktubeAnisotropicDiffusiveSparseRegistrationFilter.h
+++ b/TubeTKLib/Registration/itktubeAnisotropicDiffusiveSparseRegistrationFilter.h
@@ -455,7 +455,7 @@ private:
    * acquire an output region that it passes to
    * ThreadedGetNormalsAndDistancesFromClosestSurfacePoint for
    * processing. */
-  static ITK_THREAD_RETURN_TYPE
+  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
       GetNormalsAndDistancesFromClosestSurfacePointThreaderCallback(
           void * arg );
 

--- a/TubeTKLib/Registration/itktubeAnisotropicDiffusiveSparseRegistrationFilter.hxx
+++ b/TubeTKLib/Registration/itktubeAnisotropicDiffusiveSparseRegistrationFilter.hxx
@@ -600,7 +600,7 @@ AnisotropicDiffusiveSparseRegistrationFilter
  * processing
  */
 template< class TFixedImage, class TMovingImage, class TDeformationField >
-ITK_THREAD_RETURN_TYPE
+ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 AnisotropicDiffusiveSparseRegistrationFilter
   < TFixedImage, TMovingImage, TDeformationField >
 ::GetNormalsAndDistancesFromClosestSurfacePointThreaderCallback(

--- a/TubeTKLib/Registration/itktubeDiffusiveRegistrationFilter.h
+++ b/TubeTKLib/Registration/itktubeDiffusiveRegistrationFilter.h
@@ -859,25 +859,26 @@ private:
   /** This callback method uses ImageSource::SplitRequestedRegion to
    * acquire an
    * output region that it passes to ThreadedApplyUpdate for processing. */
-  static ITK_THREAD_RETURN_TYPE ApplyUpdateThreaderCallback( void *arg );
+  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
+    ApplyUpdateThreaderCallback( void *arg );
 
   /** This callback method uses SplitUpdateContainer to acquire a region
    * which it then passes to ThreadedCalculateChange for processing. */
-  static ITK_THREAD_RETURN_TYPE CalculateChangeGradientThreaderCallback(
-    void *arg );
+  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
+    CalculateChangeGradientThreaderCallback( void *arg );
 
   /** This callback method uses SplitUpdateContainer to acquire a region
    * which it then passes to
    * ThreadedComputeDeformationComponentDerivativeImageHelper
    * for processing. */
-  static ITK_THREAD_RETURN_TYPE
-      ComputeDeformationComponentDerivativeImageHelperThreaderCallback(
-          void *arg );
+  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
+   ComputeDeformationComponentDerivativeImageHelperThreaderCallback(
+     void *arg );
 
   /** This callback method uses SplitUpdateContainer to acquire a region
    * which it then passes to ThreadedComputeEnergies for processing. */
-  static ITK_THREAD_RETURN_TYPE CalculateEnergiesThreaderCallback(
-    void *arg );
+  static ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
+    CalculateEnergiesThreaderCallback( void *arg );
 
   TimeStepType                              m_OriginalTimeStep;
 

--- a/TubeTKLib/Registration/itktubeDiffusiveRegistrationFilter.hxx
+++ b/TubeTKLib/Registration/itktubeDiffusiveRegistrationFilter.hxx
@@ -652,7 +652,7 @@ DiffusiveRegistrationFilter
  * processing
  */
 template< class TFixedImage, class TMovingImage, class TDeformationField >
-ITK_THREAD_RETURN_TYPE
+ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 DiffusiveRegistrationFilter
   < TFixedImage, TMovingImage, TDeformationField >
 ::ComputeDeformationComponentDerivativeImageHelperThreaderCallback(
@@ -952,7 +952,7 @@ DiffusiveRegistrationFilter
  * Calls ThreadedCalculateChangeGradient for processing
  */
 template< class TFixedImage, class TMovingImage, class TDeformationField >
-ITK_THREAD_RETURN_TYPE
+ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 DiffusiveRegistrationFilter
   < TFixedImage, TMovingImage, TDeformationField >
 ::CalculateChangeGradientThreaderCallback( void * arg )
@@ -1334,7 +1334,7 @@ DiffusiveRegistrationFilter
  * Calls ThreadedCalculateEnergies for processing
  */
 template< class TFixedImage, class TMovingImage, class TDeformationField >
-ITK_THREAD_RETURN_TYPE
+ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 DiffusiveRegistrationFilter
   < TFixedImage, TMovingImage, TDeformationField >
 ::CalculateEnergiesThreaderCallback( void * arg )
@@ -1688,7 +1688,7 @@ DiffusiveRegistrationFilter
  * diffusion tensor image
  */
 template< class TFixedImage, class TMovingImage, class TDeformationField >
-ITK_THREAD_RETURN_TYPE
+ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION
 DiffusiveRegistrationFilter
   < TFixedImage, TMovingImage, TDeformationField >
 ::ApplyUpdateThreaderCallback( void * arg )


### PR DESCRIPTION
ITKv5 uses ITK_THREAD_RETURN_FUNCTION_CALL_CONVENTION to manage
the signatures of thread callback functions.
This type changes per platform, so the callback functions
must now use it as a return type instead of ITK_THREAD_RETURN_TYPE.